### PR TITLE
Python3対応と構造化と高速化

### DIFF
--- a/netcon.py
+++ b/netcon.py
@@ -61,7 +61,7 @@ class NetconClass:
         n = len(self.prime_tensors)
         xi_min = float(min(self.BOND_DIMS))
         mu_cap = 1.0
-        mu_old = 0.0
+        mu_old = 0.0 #>=0
 
         while len(tensors_of_size[-1])<1:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
@@ -76,10 +76,9 @@ class NetconClass:
                             if self._is_disjoint(t1,t2): continue
 
                             mu = self._get_cost(t1,t2)
-                            mu_0 = 0.0 if (t1.is_new or t2.is_new) else mu_old
 
                             if (mu > mu_cap) and (mu < mu_next): mu_next = mu
-                            if (mu > mu_0) and (mu <= mu_cap):
+                            if (t1.is_new or t2.is_new or mu_old < mu) and (mu <= mu_cap):
                                 t_new = self._contract(t1,t2)
                                 is_find = False
                                 for i,t_old in enumerate(tensors_of_size[c]):

--- a/netcon.py
+++ b/netcon.py
@@ -77,7 +77,7 @@ class NetconClass:
 
                             mu = self._get_cost(t1,t2)
 
-                            if (mu > mu_cap) and (mu < mu_next): mu_next = mu
+                            if mu_cap < mu < mu_next: mu_next = mu
                             if (t1.is_new or t2.is_new or mu_old < mu) and (mu <= mu_cap):
                                 t_new = self._contract(t1,t2)
                                 is_find = False

--- a/netcon.py
+++ b/netcon.py
@@ -67,15 +67,18 @@ class NetconClass:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
             for c in range(1,n):
+                cp1 = c+1
                 for d1 in range((c+1)//2):
-                    d2 = c-d1-1
-                    n1 = len(tensors_of_size[d1+1])
-                    n2 = len(tensors_of_size[d2+1])
+                    d1p1 = d1+1
+                    d2 = c-d1p1
+                    d2p1 = d2+1
+                    n1 = len(tensors_of_size[d1p1])
+                    n2 = len(tensors_of_size[d2p1])
                     for i1 in range(n1):
-                        i2_start = i1+1 if d1==d2 else 0
+                        i2_start = i1+1 if d1p1==d2p1 else 0
                         for i2 in range(i2_start, n2):
-                            t1 = tensors_of_size[d1+1][i1]
-                            t2 = tensors_of_size[d2+1][i2]
+                            t1 = tensors_of_size[d1p1][i1]
+                            t2 = tensors_of_size[d2p1][i2]
 
                             if self._is_disjoint(t1,t2): continue
                             if self._is_overlap(t1,t2): continue
@@ -87,13 +90,13 @@ class NetconClass:
                             if (mu > mu_0) and (mu <= mu_cap):
                                 t_new = self._contract(t1,t2)
                                 is_find = False
-                                for i,t_old in enumerate(tensors_of_size[c+1]):
+                                for i,t_old in enumerate(tensors_of_size[cp1]):
                                     if t_new.bits == t_old.bits:
                                         if t_new.cost < t_old.cost:
-                                            tensors_of_size[c+1][i] = t_new
+                                            tensors_of_size[cp1][i] = t_new
                                         is_find = True
                                         break
-                                if not is_find: tensors_of_size[c+1].append(t_new)
+                                if not is_find: tensors_of_size[cp1].append(t_new)
             mu_old = mu_cap
             mu_cap = max(mu_next, mu_cap*xi_min)
             for s in tensors_of_size:

--- a/netcon.py
+++ b/netcon.py
@@ -66,8 +66,7 @@ class NetconClass:
         while len(tensors_of_size[-1])<1:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
-            for c in range(1,n):
-                cp1 = c+1
+            for cp1 in range(2,n+1):
                 for d1p1 in range(1,(cp1)//2+1):
                     d2p1 = cp1-d1p1
                     n1 = len(tensors_of_size[d1p1])

--- a/netcon.py
+++ b/netcon.py
@@ -66,16 +66,16 @@ class NetconClass:
         while len(tensors_of_size[-1])<1:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
-            for cp1 in range(2,n+1):
-                for d1p1 in range(1,(cp1)//2+1):
-                    d2p1 = cp1-d1p1
-                    n1 = len(tensors_of_size[d1p1])
-                    n2 = len(tensors_of_size[d2p1])
+            for c in range(2,n+1):
+                for d1 in range(1,c//2+1):
+                    d2 = c-d1
+                    n1 = len(tensors_of_size[d1])
+                    n2 = len(tensors_of_size[d2])
                     for i1 in range(n1):
-                        i2_start = i1+1 if d1p1==d2p1 else 0
+                        i2_start = i1+1 if d1==d2 else 0
                         for i2 in range(i2_start, n2):
-                            t1 = tensors_of_size[d1p1][i1]
-                            t2 = tensors_of_size[d2p1][i2]
+                            t1 = tensors_of_size[d1][i1]
+                            t2 = tensors_of_size[d2][i2]
 
                             if self._is_disjoint(t1,t2): continue
                             if self._is_overlap(t1,t2): continue
@@ -87,13 +87,13 @@ class NetconClass:
                             if (mu > mu_0) and (mu <= mu_cap):
                                 t_new = self._contract(t1,t2)
                                 is_find = False
-                                for i,t_old in enumerate(tensors_of_size[cp1]):
+                                for i,t_old in enumerate(tensors_of_size[c]):
                                     if t_new.bits == t_old.bits:
                                         if t_new.cost < t_old.cost:
-                                            tensors_of_size[cp1][i] = t_new
+                                            tensors_of_size[c][i] = t_new
                                         is_find = True
                                         break
-                                if not is_find: tensors_of_size[cp1].append(t_new)
+                                if not is_find: tensors_of_size[c].append(t_new)
             mu_old = mu_cap
             mu_cap = max(mu_next, mu_cap*xi_min)
             for s in tensors_of_size:

--- a/netcon.py
+++ b/netcon.py
@@ -72,8 +72,8 @@ class NetconClass:
                     for i1, t1 in enumerate(tensors_of_size[d1]):
                         i2_start = i1+1 if d1==d2 else 0
                         for t2 in tensors_of_size[d2][i2_start:]:
-                            if self._is_disjoint(t1,t2): continue
                             if self._is_overlap(t1,t2): continue
+                            if self._is_disjoint(t1,t2): continue
 
                             mu = self._get_cost(t1,t2)
                             mu_0 = 0.0 if (t1.is_new or t2.is_new) else mu_old

--- a/netcon.py
+++ b/netcon.py
@@ -30,9 +30,13 @@ class Tensor:
         self.cost = cost
         self.is_new = is_new
 
+    def __repr__(self):
+        return "Tensor({0}, bonds={1}, cost={2:.6e}, bit={3}, is_new={4})".format(
+            self.rpn, self.bonds, self.cost, self.bit, self.is_new)
+
     def __str__(self):
-        return "{0} : bond={1} cost={2:.6e} bit={3}  new={4}".format(
-            self.rpn, list(self.bonds), self.cost, self.bit, self.is_new)
+        return "{0} : bond={1} cost={2:.6e} bit={3} new={4}".format(
+            self.rpn, self.bonds, self.cost, self.bit, self.is_new)
 
 
 class NetconClass:
@@ -59,6 +63,7 @@ class NetconClass:
         mu_old = 0.0
 
         while len(tensor_set[-1])<1:
+            #print(tensor_set)
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
             for c in range(1,n):

--- a/netcon.py
+++ b/netcon.py
@@ -41,6 +41,7 @@ class HistTensorFrame:
 
 class NetconClass:
     def __init__(self, tensors, bond_dims):
+        #print(tensors)
         self.tensors = tensors
         self.BOND_DIMS = bond_dims[:]
 
@@ -101,7 +102,7 @@ class NetconClass:
             logging.debug("netcon: tensor_num=" +  str([ len(s) for s in tensor_set]))
 
         t_final = tensor_set[-1][0]
-        print(t_final.rpn)
+        #print(t_final.rpn)
         return t_final.rpn, t_final.cost
 
 

--- a/netcon.py
+++ b/netcon.py
@@ -69,14 +69,9 @@ class NetconClass:
             for c in range(2,n+1):
                 for d1 in range(1,c//2+1):
                     d2 = c-d1
-                    n1 = len(tensors_of_size[d1])
-                    n2 = len(tensors_of_size[d2])
-                    for i1 in range(n1):
+                    for i1, t1 in enumerate(tensors_of_size[d1]):
                         i2_start = i1+1 if d1==d2 else 0
-                        for i2 in range(i2_start, n2):
-                            t1 = tensors_of_size[d1][i1]
-                            t2 = tensors_of_size[d2][i2]
-
+                        for i2, t2 in enumerate(tensors_of_size[d2][i2_start:]):
                             if self._is_disjoint(t1,t2): continue
                             if self._is_overlap(t1,t2): continue
 

--- a/netcon.py
+++ b/netcon.py
@@ -71,7 +71,7 @@ class NetconClass:
                     d2 = c-d1
                     for i1, t1 in enumerate(tensors_of_size[d1]):
                         i2_start = i1+1 if d1==d2 else 0
-                        for i2, t2 in enumerate(tensors_of_size[d2][i2_start:]):
+                        for t2 in tensors_of_size[d2][i2_start:]:
                             if self._is_disjoint(t1,t2): continue
                             if self._is_overlap(t1,t2): continue
 

--- a/netcon.py
+++ b/netcon.py
@@ -14,7 +14,7 @@ import config
 import itertools
 
 
-class HistTensorFrame:
+class TensorFrame:
     """Tensor class for netcon.
 
     Attributes:
@@ -32,7 +32,7 @@ class HistTensorFrame:
         self.is_new = is_new
 
     def __repr__(self):
-        return "HistTensorFrame({0}, bonds={1}, cost={2:.6e}, bits={3}, is_new={4})".format(
+        return "TensorFrame({0}, bonds={1}, cost={2:.6e}, bits={3}, is_new={4})".format(
             self.rpn, self.bonds, self.cost, self.bits, self.is_new)
 
     def __str__(self):
@@ -40,12 +40,12 @@ class HistTensorFrame:
             self.rpn, self.bonds, self.cost, self.bits, self.is_new)
 
 
-class NetconClass:
+class NetconOptimizer:
     def __init__(self, prime_tensors, bond_dims):
         self.prime_tensors = prime_tensors
         self.BOND_DIMS = bond_dims[:]
 
-    def calc(self):
+    def optimize(self):
         """Find optimal contraction sequence.
 
         Args:
@@ -106,7 +106,7 @@ class NetconClass:
                 if i>=0: bits += (1<<i)
             bonds = frozenset(t.bonds)
             cost = 0.0
-            tensordict_of_size[1].update({bits:HistTensorFrame(rpn,bits,bonds,cost)})
+            tensordict_of_size[1].update({bits:TensorFrame(rpn,bits,bonds,cost)})
         return tensordict_of_size
 
 
@@ -126,7 +126,7 @@ class NetconClass:
         bits = t1.bits ^ t2.bits # XOR
         bonds = frozenset(t1.bonds ^ t2.bonds)
         cost = self.get_contracting_cost(t1,t2)
-        return HistTensorFrame(rpn,bits,bonds,cost)
+        return TensorFrame(rpn,bits,bonds,cost)
 
 
     def are_direct_product(self,t1,t2):

--- a/netcon.py
+++ b/netcon.py
@@ -40,8 +40,8 @@ class HistTensorFrame:
 
 
 class NetconClass:
-    def __init__(self, tn, bond_dims):
-        self.tn = tn
+    def __init__(self, tensors, bond_dims):
+        self.tensors = tensors
         self.BOND_DIMS = bond_dims[:]
 
     def calc(self):
@@ -107,8 +107,8 @@ class NetconClass:
 
     def _init_tensor_set(self):
         """Initialize a set of tensors from tdt tensor-network."""
-        tensor_set = [[] for t in self.tn.tensors]
-        for t in self.tn.tensors:
+        tensor_set = [[] for t in self.tensors]
+        for t in self.tensors:
             rpn = t.name
             bits = 0
             for i in rpn:

--- a/netcon.py
+++ b/netcon.py
@@ -18,25 +18,25 @@ class Tensor:
 
     Attributes:
         rpn: contraction sequence with reverse polish notation.
-        bit: bit representation of contracted tensors.
+        bits: bits representation of contracted tensors.
         bonds: list of bonds connecting with the outside.
         is_new: a flag.
     """
 
-    def __init__(self,rpn=[],bit=0,bonds=[],cost=0.0,is_new=True):
+    def __init__(self,rpn=[],bits=0,bonds=[],cost=0.0,is_new=True):
         self.rpn = rpn[:]
-        self.bit = bit
+        self.bits = bits
         self.bonds = bonds
         self.cost = cost
         self.is_new = is_new
 
     def __repr__(self):
-        return "Tensor({0}, bonds={1}, cost={2:.6e}, bit={3}, is_new={4})".format(
-            self.rpn, self.bonds, self.cost, self.bit, self.is_new)
+        return "Tensor({0}, bonds={1}, cost={2:.6e}, bits={3}, is_new={4})".format(
+            self.rpn, self.bonds, self.cost, self.bits, self.is_new)
 
     def __str__(self):
-        return "{0} : bond={1} cost={2:.6e} bit={3} new={4}".format(
-            self.rpn, self.bonds, self.cost, self.bit, self.is_new)
+        return "{0} : bonds={1} cost={2:.6e} bits={3} new={4}".format(
+            self.rpn, self.bonds, self.cost, self.bits, self.is_new)
 
 
 class NetconClass:
@@ -63,7 +63,7 @@ class NetconClass:
         mu_old = 0.0
 
         while len(tensor_set[-1])<1:
-            #print(tensor_set)
+            print(tensor_set)
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
             for c in range(1,n):
@@ -88,7 +88,7 @@ class NetconClass:
                                 t_new = self._contract(t1,t2)
                                 is_find = False
                                 for i,t_old in enumerate(tensor_set[c]):
-                                    if t_new.bit == t_old.bit:
+                                    if t_new.bits == t_old.bits:
                                         if t_new.cost < t_old.cost:
                                             tensor_set[c][i] = t_new
                                         is_find = True
@@ -110,12 +110,12 @@ class NetconClass:
         tensor_set = [[] for t in self.tn.tensors]
         for t in self.tn.tensors:
             rpn = t.name
-            bit = 0
+            bits = 0
             for i in rpn:
-                if i>=0: bit += (1<<i)
+                if i>=0: bits += (1<<i)
             bonds = frozenset(t.bonds)
             cost = 0.0
-            tensor_set[0].append(Tensor(rpn,bit,bonds,cost))
+            tensor_set[0].append(Tensor(rpn,bits,bonds,cost))
         return tensor_set
 
 
@@ -132,10 +132,10 @@ class NetconClass:
         """Return a contracted tensor"""
         assert (not self._is_disjoint(t1,t2))
         rpn = t1.rpn + t2.rpn + [-1]
-        bit = t1.bit ^ t2.bit # XOR
+        bits = t1.bits ^ t2.bits # XOR
         bonds = frozenset(t1.bonds ^ t2.bonds)
         cost = self._get_cost(t1,t2)
-        return Tensor(rpn,bit,bonds,cost)
+        return Tensor(rpn,bits,bonds,cost)
 
 
     def _is_disjoint(self,t1,t2):
@@ -145,7 +145,7 @@ class NetconClass:
 
     def _is_overlap(self,t1,t2):
         """Check if two tensors have the same basic tensor."""
-        return (t1.bit & t2.bit)>0
+        return (t1.bits & t2.bits)>0
 
 
     def _print_tset(self,tensor_set):

--- a/netcon.py
+++ b/netcon.py
@@ -65,7 +65,7 @@ class NetconClass:
 
         while len(tensors_of_size[-1])<1:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
-            mu_next = sys.float_info.max
+            next_mu_cap = sys.float_info.max
             for c in range(2,n+1):
                 for d1 in range(1,c//2+1):
                     d2 = c-d1
@@ -77,7 +77,8 @@ class NetconClass:
 
                             mu = self.get_contracting_cost(t1,t2)
 
-                            if mu_cap < mu < mu_next: mu_next = mu
+                            assert mu_cap <= next_mu_cap
+                            if mu_cap < mu < next_mu_cap: next_mu_cap = mu
                             if (t1.is_new or t2.is_new or mu_old < mu) and (mu <= mu_cap):
                                 t_new = self.contract(t1,t2)
                                 is_find = False
@@ -89,7 +90,7 @@ class NetconClass:
                                         break
                                 if not is_find: tensors_of_size[c].append(t_new)
             mu_old = mu_cap
-            mu_cap = max(mu_next, mu_cap*xi_min)
+            mu_cap = max(next_mu_cap, mu_cap*xi_min)
             for s in tensors_of_size:
                 for t in s: t.is_new = False
 

--- a/netcon.py
+++ b/netcon.py
@@ -12,7 +12,6 @@ import logging
 import time
 import config
 
-BOND_DIMS = []
 
 class Tensor:
     """Tensor class for netcon.
@@ -36,113 +35,117 @@ class Tensor:
             self.rpn, list(self.bonds), self.cost, self.bit, self.is_new)
 
 
-def netcon(tn, bond_dims):
-    """Find optimal contraction sequence.
+class NetconClass:
+    def __init__(self, tn, bond_dims):
+        self.tn = tn
+        self.BOND_DIMS = bond_dims[:]
 
-    Args:
-        tn: TensorNetwork in tdt.py
-        bond_dims: List of bond dimensions.
+    def calc(self):
+        """Find optimal contraction sequence.
 
-    Return:
-        rpn: Optimal contraction sequence with reverse polish notation.
-        cost: Total contraction cost.
-    """
-    BOND_DIMS[0:0] = bond_dims
-    tensor_set = _init(tn)
+        Args:
+            tn: TensorNetwork in tdt.py
+            bond_dims: List of bond dimensions.
 
-    n = len(tensor_set[0])
-    xi_min = float(min(BOND_DIMS))
-    mu_cap = 1.0
-    mu_old = 0.0
+        Return:
+            rpn: Optimal contraction sequence with reverse polish notation.
+            cost: Total contraction cost.
+        """
+        tensor_set = self._init(self.tn)
 
-    while len(tensor_set[-1])<1:
-        logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
-        mu_next = sys.float_info.max
-        for c in range(1,n):
-            for d1 in range((c+1)//2):
-                d2 = c-d1-1
-                n1 = len(tensor_set[d1])
-                n2 = len(tensor_set[d2])
-                for i1 in range(n1):
-                    i2_start = i1+1 if d1==d2 else 0
-                    for i2 in range(i2_start, n2):
-                        t1 = tensor_set[d1][i1]
-                        t2 = tensor_set[d2][i2]
+        n = len(tensor_set[0])
+        xi_min = float(min(self.BOND_DIMS))
+        mu_cap = 1.0
+        mu_old = 0.0
 
-                        if _is_disjoint(t1,t2): continue
-                        if _is_overlap(t1,t2): continue
+        while len(tensor_set[-1])<1:
+            logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
+            mu_next = sys.float_info.max
+            for c in range(1,n):
+                for d1 in range((c+1)//2):
+                    d2 = c-d1-1
+                    n1 = len(tensor_set[d1])
+                    n2 = len(tensor_set[d2])
+                    for i1 in range(n1):
+                        i2_start = i1+1 if d1==d2 else 0
+                        for i2 in range(i2_start, n2):
+                            t1 = tensor_set[d1][i1]
+                            t2 = tensor_set[d2][i2]
 
-                        mu = _get_cost(t1,t2)
-                        mu_0 = 0.0 if (t1.is_new or t2.is_new) else mu_old
+                            if self._is_disjoint(t1,t2): continue
+                            if self._is_overlap(t1,t2): continue
 
-                        if (mu > mu_cap) and (mu < mu_next): mu_next = mu
-                        if (mu > mu_0) and (mu <= mu_cap):
-                            t_new = _contract(t1,t2)
-                            is_find = False
-                            for i,t_old in enumerate(tensor_set[c]):
-                                if t_new.bit == t_old.bit:
-                                    if t_new.cost < t_old.cost:
-                                        tensor_set[c][i] = t_new
-                                    is_find = True
-                                    break
-                            if not is_find: tensor_set[c].append(t_new)
-        mu_old = mu_cap
-        mu_cap = max(mu_next, mu_cap*xi_min)
-        for s in tensor_set:
-            for t in s: t.is_new = False
+                            mu = self._get_cost(t1,t2)
+                            mu_0 = 0.0 if (t1.is_new or t2.is_new) else mu_old
 
-        logging.debug("netcon: tensor_num=" +  str([ len(s) for s in tensor_set]))
+                            if (mu > mu_cap) and (mu < mu_next): mu_next = mu
+                            if (mu > mu_0) and (mu <= mu_cap):
+                                t_new = self._contract(t1,t2)
+                                is_find = False
+                                for i,t_old in enumerate(tensor_set[c]):
+                                    if t_new.bit == t_old.bit:
+                                        if t_new.cost < t_old.cost:
+                                            tensor_set[c][i] = t_new
+                                        is_find = True
+                                        break
+                                if not is_find: tensor_set[c].append(t_new)
+            mu_old = mu_cap
+            mu_cap = max(mu_next, mu_cap*xi_min)
+            for s in tensor_set:
+                for t in s: t.is_new = False
 
-    t_final = tensor_set[-1][0]
-    return t_final.rpn, t_final.cost
+            logging.debug("netcon: tensor_num=" +  str([ len(s) for s in tensor_set]))
 
-
-def _init(tn):
-    """Initialize a set of tensors from tdt tensor-network."""
-    tensor_set = [[] for t in tn.tensors]
-    for t in tn.tensors:
-        rpn = t.name
-        bit = 0
-        for i in rpn:
-            if i>=0: bit += (1<<i)
-        bonds = frozenset(t.bonds)
-        cost = 0.0
-        tensor_set[0].append(Tensor(rpn,bit,bonds,cost))
-    return tensor_set
+        t_final = tensor_set[-1][0]
+        return t_final.rpn, t_final.cost
 
 
-def _get_cost(t1,t2):
-    """Get the cost of contraction of two tensors."""
-    cost = 1.0
-    for b in (t1.bonds | t2.bonds):
-        cost *= BOND_DIMS[b]
-    cost += t1.cost + t2.cost
-    return cost
+    def _init(self,tn):
+        """Initialize a set of tensors from tdt tensor-network."""
+        tensor_set = [[] for t in tn.tensors]
+        for t in tn.tensors:
+            rpn = t.name
+            bit = 0
+            for i in rpn:
+                if i>=0: bit += (1<<i)
+            bonds = frozenset(t.bonds)
+            cost = 0.0
+            tensor_set[0].append(Tensor(rpn,bit,bonds,cost))
+        return tensor_set
 
 
-def _contract(t1,t2):
-    """Return a contracted tensor"""
-    assert (not _is_disjoint(t1,t2))
-    rpn = t1.rpn + t2.rpn + [-1]
-    bit = t1.bit ^ t2.bit # XOR
-    bonds = frozenset(t1.bonds ^ t2.bonds)
-    cost = _get_cost(t1,t2)
-    return Tensor(rpn,bit,bonds,cost)
+    def _get_cost(self,t1,t2):
+        """Get the cost of contraction of two tensors."""
+        cost = 1.0
+        for b in (t1.bonds | t2.bonds):
+            cost *= self.BOND_DIMS[b]
+        cost += t1.cost + t2.cost
+        return cost
 
 
-def _is_disjoint(t1,t2):
-    """Check if two tensors are disjoint."""
-    return (t1.bonds).isdisjoint(t2.bonds)
+    def _contract(self,t1,t2):
+        """Return a contracted tensor"""
+        assert (not self._is_disjoint(t1,t2))
+        rpn = t1.rpn + t2.rpn + [-1]
+        bit = t1.bit ^ t2.bit # XOR
+        bonds = frozenset(t1.bonds ^ t2.bonds)
+        cost = self._get_cost(t1,t2)
+        return Tensor(rpn,bit,bonds,cost)
 
 
-def _is_overlap(t1,t2):
-    """Check if two tensors have the same basic tensor."""
-    return (t1.bit & t2.bit)>0
+    def _is_disjoint(self,t1,t2):
+        """Check if two tensors are disjoint."""
+        return (t1.bonds).isdisjoint(t2.bonds)
 
 
-def _print_tset(tensor_set):
-    """Print tensor_set. (for debug)"""
-    for level in range(len(tensor_set)):
-        for i,t in enumerate(tensor_set[level]):
-            print(level,i,t)
+    def _is_overlap(self,t1,t2):
+        """Check if two tensors have the same basic tensor."""
+        return (t1.bit & t2.bit)>0
+
+
+    def _print_tset(self,tensor_set):
+        """Print tensor_set. (for debug)"""
+        for level in range(len(tensor_set)):
+            for i,t in enumerate(tensor_set[level]):
+                print(level,i,t)
 

--- a/netcon.py
+++ b/netcon.py
@@ -59,7 +59,7 @@ def netcon(tn, bond_dims):
         logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
         mu_next = sys.float_info.max
         for c in range(1,n):
-            for d1 in range((c+1)/2):
+            for d1 in range((c+1)//2):
                 d2 = c-d1-1
                 n1 = len(tensor_set[d1])
                 n2 = len(tensor_set[d2])
@@ -144,5 +144,5 @@ def _print_tset(tensor_set):
     """Print tensor_set. (for debug)"""
     for level in range(len(tensor_set)):
         for i,t in enumerate(tensor_set[level]):
-            print level,i,t
+            print(level,i,t)
 

--- a/netcon.py
+++ b/netcon.py
@@ -83,10 +83,9 @@ class NetconClass:
                             next_mu_cap = mu
                         elif t1.is_new or t2.is_new or prev_mu_cap < mu:
                             t_new = self.contract(t1,t2)
-                            if t_new.bits in tensordict_of_size[c]:
-                                t_old = tensordict_of_size[c][t_new.bits]
-                                if t_new.cost < t_old.cost:
-                                    tensordict_of_size[c][t_new.bits] = t_new
+                            t_old = tensordict_of_size[c].get(t_new.bits)
+                            if t_old is not None and t_new.cost < t_old.cost:
+                                tensordict_of_size[c][t_new.bits] = t_new
                             else:
                                 tensordict_of_size[c][t_new.bits] = t_new
             prev_mu_cap = mu_cap

--- a/netcon.py
+++ b/netcon.py
@@ -74,19 +74,17 @@ class NetconClass:
                         if self.are_overlap(t1,t2): continue
                         if self.are_direct_product(t1,t2): continue
 
-                        mu = self.get_contracting_cost(t1,t2)
+                        cost = self.get_contracting_cost(t1,t2)
+                        bits = t1.bits ^ t2.bits
 
-                        if next_mu_cap <= mu:
+                        if next_mu_cap <= cost:
                             pass
-                        elif mu_cap < mu:
-                            next_mu_cap = mu
-                        elif t1.is_new or t2.is_new or prev_mu_cap < mu:
-                            t_new = self.contract(t1,t2)
-                            t_old = tensordict_of_size[c].get(t_new.bits)
-                            if t_old is not None and t_new.cost < t_old.cost:
-                                tensordict_of_size[c][t_new.bits] = t_new
-                            else:
-                                tensordict_of_size[c][t_new.bits] = t_new
+                        elif mu_cap < cost:
+                            next_mu_cap = cost
+                        elif t1.is_new or t2.is_new or prev_mu_cap < cost:
+                            t_old = tensordict_of_size[c].get(bits)
+                            if t_old is None or cost < t_old.cost:
+                                tensordict_of_size[c][bits] = self.contract(t1,t2)
             prev_mu_cap = mu_cap
             mu_cap = max(next_mu_cap, mu_cap*xi_min)
             for s in tensordict_of_size:

--- a/netcon.py
+++ b/netcon.py
@@ -13,13 +13,13 @@ import time
 import config
 
 
-class Tensor:
+class HistTensorFrame:
     """Tensor class for netcon.
 
     Attributes:
         rpn: contraction sequence with reverse polish notation.
         bits: bits representation of contracted tensors.
-        bonds: list of bonds connecting with the outside.
+        bonds: list of uncontracted bonds.
         is_new: a flag.
     """
 
@@ -31,7 +31,7 @@ class Tensor:
         self.is_new = is_new
 
     def __repr__(self):
-        return "Tensor({0}, bonds={1}, cost={2:.6e}, bits={3}, is_new={4})".format(
+        return "HistTensorFrame({0}, bonds={1}, cost={2:.6e}, bits={3}, is_new={4})".format(
             self.rpn, self.bonds, self.cost, self.bits, self.is_new)
 
     def __str__(self):
@@ -63,7 +63,6 @@ class NetconClass:
         mu_old = 0.0
 
         while len(tensor_set[-1])<1:
-            print(tensor_set)
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
             mu_next = sys.float_info.max
             for c in range(1,n):
@@ -102,6 +101,7 @@ class NetconClass:
             logging.debug("netcon: tensor_num=" +  str([ len(s) for s in tensor_set]))
 
         t_final = tensor_set[-1][0]
+        print(t_final.rpn)
         return t_final.rpn, t_final.cost
 
 
@@ -115,7 +115,7 @@ class NetconClass:
                 if i>=0: bits += (1<<i)
             bonds = frozenset(t.bonds)
             cost = 0.0
-            tensor_set[0].append(Tensor(rpn,bits,bonds,cost))
+            tensor_set[0].append(HistTensorFrame(rpn,bits,bonds,cost))
         return tensor_set
 
 
@@ -135,7 +135,7 @@ class NetconClass:
         bits = t1.bits ^ t2.bits # XOR
         bonds = frozenset(t1.bonds ^ t2.bonds)
         cost = self._get_cost(t1,t2)
-        return Tensor(rpn,bits,bonds,cost)
+        return HistTensorFrame(rpn,bits,bonds,cost)
 
 
     def _is_disjoint(self,t1,t2):

--- a/netcon.py
+++ b/netcon.py
@@ -40,9 +40,9 @@ class HistTensorFrame:
 
 
 class NetconClass:
-    def __init__(self, tensors, bond_dims):
+    def __init__(self, prime_tensors, bond_dims):
         #print(tensors)
-        self.tensors = tensors
+        self.prime_tensors = prime_tensors
         self.BOND_DIMS = bond_dims[:]
 
     def calc(self):
@@ -108,8 +108,8 @@ class NetconClass:
 
     def _init_tensors_of_size_plus1(self):
         """tensors_of_size_plus1[k] == calculated tensors which is contraction of k+1 prime tensors"""
-        tensors_of_size_plus1 = [[] for t in self.tensors]
-        for t in self.tensors:
+        tensors_of_size_plus1 = [[] for t in self.prime_tensors]
+        for t in self.prime_tensors:
             rpn = t.name
             bits = 0
             for i in rpn:

--- a/netcon.py
+++ b/netcon.py
@@ -42,7 +42,6 @@ class HistTensorFrame:
 
 class NetconClass:
     def __init__(self, prime_tensors, bond_dims):
-        #print(tensors)
         self.prime_tensors = prime_tensors
         self.BOND_DIMS = bond_dims[:]
 
@@ -96,7 +95,6 @@ class NetconClass:
             logging.debug("netcon: tensor_num=" +  str([ len(s) for s in tensordict_of_size]))
 
         t_final = tensordict_of_size[-1][(1<<n)-1]
-        #print(t_final.rpn)
         return t_final.rpn, t_final.cost
 
 

--- a/netcon.py
+++ b/netcon.py
@@ -61,7 +61,7 @@ class NetconClass:
         n = len(self.prime_tensors)
         xi_min = float(min(self.BOND_DIMS))
         mu_cap = 1.0
-        mu_old = 0.0 #>=0
+        prev_mu_cap = 0.0 #>=0
 
         while len(tensors_of_size[-1])<1:
             logging.info("netcon: searching with mu_cap={0:.6e}".format(mu_cap))
@@ -81,7 +81,7 @@ class NetconClass:
                                 pass
                             elif mu_cap < mu:
                                 next_mu_cap = mu
-                            elif t1.is_new or t2.is_new or mu_old < mu:
+                            elif t1.is_new or t2.is_new or prev_mu_cap < mu:
                                 t_new = self.contract(t1,t2)
                                 is_find = False
                                 for i,t_old in enumerate(tensors_of_size[c]):
@@ -91,7 +91,7 @@ class NetconClass:
                                         is_find = True
                                         break
                                 if not is_find: tensors_of_size[c].append(t_new)
-            mu_old = mu_cap
+            prev_mu_cap = mu_cap
             mu_cap = max(next_mu_cap, mu_cap*xi_min)
             for s in tensors_of_size:
                 for t in s: t.is_new = False

--- a/netcon.py
+++ b/netcon.py
@@ -51,7 +51,7 @@ class NetconClass:
             rpn: Optimal contraction sequence with reverse polish notation.
             cost: Total contraction cost.
         """
-        tensor_set = self._init(self.tn)
+        tensor_set = self._init_tensor_set()
 
         n = len(tensor_set[0])
         xi_min = float(min(self.BOND_DIMS))
@@ -100,10 +100,10 @@ class NetconClass:
         return t_final.rpn, t_final.cost
 
 
-    def _init(self,tn):
+    def _init_tensor_set(self):
         """Initialize a set of tensors from tdt tensor-network."""
-        tensor_set = [[] for t in tn.tensors]
-        for t in tn.tensors:
+        tensor_set = [[] for t in self.tn.tensors]
+        for t in self.tn.tensors:
             rpn = t.name
             bit = 0
             for i in rpn:

--- a/netcon.py
+++ b/netcon.py
@@ -68,8 +68,7 @@ class NetconClass:
             mu_next = sys.float_info.max
             for c in range(1,n):
                 cp1 = c+1
-                for d1 in range((c+1)//2):
-                    d1p1 = d1+1
+                for d1p1 in range(1,(cp1)//2+1):
                     d2p1 = cp1-d1p1
                     n1 = len(tensors_of_size[d1p1])
                     n2 = len(tensors_of_size[d2p1])

--- a/netcon.py
+++ b/netcon.py
@@ -77,9 +77,11 @@ class NetconClass:
 
                             mu = self.get_contracting_cost(t1,t2)
 
-                            assert mu_cap <= next_mu_cap
-                            if mu_cap < mu < next_mu_cap: next_mu_cap = mu
-                            if (t1.is_new or t2.is_new or mu_old < mu) and (mu <= mu_cap):
+                            if next_mu_cap <= mu:
+                                pass
+                            elif mu_cap < mu:
+                                next_mu_cap = mu
+                            elif t1.is_new or t2.is_new or mu_old < mu:
                                 t_new = self.contract(t1,t2)
                                 is_find = False
                                 for i,t_old in enumerate(tensors_of_size[c]):

--- a/netcon.py
+++ b/netcon.py
@@ -70,8 +70,7 @@ class NetconClass:
                 cp1 = c+1
                 for d1 in range((c+1)//2):
                     d1p1 = d1+1
-                    d2 = c-d1p1
-                    d2p1 = d2+1
+                    d2p1 = cp1-d1p1
                     n1 = len(tensors_of_size[d1p1])
                     n2 = len(tensors_of_size[d2p1])
                     for i1 in range(n1):

--- a/tdt.py
+++ b/tdt.py
@@ -452,7 +452,7 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s:%(message)s", level=config.LOGGING_LEVEL)
 
     tn.output_log("input")
-    rpn, cpu = netcon.NetconClass(tn.tensors, BOND_DIMS).calc()
+    rpn, cpu = netcon.NetconOptimizer(tn.tensors, BOND_DIMS).optimize()
     mem = get_memory(tn, rpn)
 
     TENSOR_MATH_NAMES = TENSOR_NAMES[:]

--- a/tdt.py
+++ b/tdt.py
@@ -449,7 +449,7 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s:%(message)s", level=config.LOGGING_LEVEL)
 
     tn.output_log("input")
-    rpn, cpu = netcon.netcon(tn, BOND_DIMS)
+    rpn, cpu = netcon.NetconClass(tn, BOND_DIMS).calc()
     mem = get_memory(tn, rpn)
 
     TENSOR_MATH_NAMES = TENSOR_NAMES[:]

--- a/tdt.py
+++ b/tdt.py
@@ -24,6 +24,9 @@ class Tensor:
             self.name = [name]
         self.bonds = bonds[:]
 
+    def __repr__(self):
+        return "Tensor(" + str(self.name) + ", " + str(self.bonds) +")"
+
     def __str__(self):
         return str(self.name) + ", " + str(self.bonds)
 

--- a/tdt.py
+++ b/tdt.py
@@ -449,7 +449,7 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s:%(message)s", level=config.LOGGING_LEVEL)
 
     tn.output_log("input")
-    rpn, cpu = netcon.NetconClass(tn, BOND_DIMS).calc()
+    rpn, cpu = netcon.NetconClass(tn.tensors, BOND_DIMS).calc()
     mem = get_memory(tn, rpn)
 
     TENSOR_MATH_NAMES = TENSOR_NAMES[:]


### PR DESCRIPTION
- Python3対応
- netcon.pyを構造化(これはただの好みです)
- 高速化
--- 「tensor_set: List[List[Tensor]]、tensor_set[size-1][i] == そのsizeの計算済みテンソルのうち同bitsのテンソルの中で最善の順序で縮約されたテンソルのひとつ」だったのを「tensordict_of_size: List[Dict[int:Tensor]]、tensordict_of_size[size][bits] == そのsizeでそのbitsの計算済みのテンソルのうち最善の順序で縮約されたテンソル」にした
--- いままでこれを更新する際既存の同bitsのものを全探索で検索していたところが単なるdictのアクセスになったので、O(N)->O(logN)程度の高速化
--- 実際の計算時間は./tdt.py okubo.dat が 0.088s -> 0.052s になった
- アルゴリズムの意味上の部分は全く変わってないはずです